### PR TITLE
Add convenience scripts for PyInstaller and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,24 @@ To capture USB traffic, you need to know the speed beforehand; it is specified a
 ./software/host/ovctl.py sniff <speed>
 ```
 
+To build a portable package using PyInstaller, first make sure that PyInstaller is installed into the current environment, then use the following:
+
+```sh
+cd ov_ftdi/software/host
+make # or nmake on Windows
+bash package.sh # or package.ps1 or package.bat on Windows.
+```
+
+The package will then be generated under `dist/ovctl`.
+
+Note that due to PyInstaller limitation, the target machine must be running the same OS on the same architecture as the host machine.
+
+The portable executable targeting Linux will ship with the udev rule file under `udev/` directory. Install it first to `/etc/udev/rules.d/` before running the package on another Linux machine.
+
 Project Status
 ==============
 
-(as of October 2019):
+(as of Feburary 2022):
 
 The hardware design and the FPGA *gateware* are considered stable and reliable,
 and have not been touched since late 2014.
@@ -44,9 +58,9 @@ USB packets in near real-time. Alternatively the host software can save captures
 
 There is basic integration with Wireshark using the extcap interface. The ovextcap available at https://github.com/matwey/libopenvizsla is known to work on Windows and Linux.
 
-There is no code to aggregate packets into transfers. Future Wireshark versions will reassemble packets into transfers and pass the data to upper layer dissectors (HID, Audio, Mass Storage, CCID, DFU, etc.). The Wireshark dissector progress is tracked at https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=15908
+Since Wireshark 3.6.0, USBLL packet reassembly is supported. Wireshark will now reassemble packets into transfers and pass the data to upper layer dissectors (HID, Audio, Mass Storage, CCID, DFU, etc.). Use the filter expression `!(frame.protocols == "usbll")` to hide low level packets.
 
-There's **no integration with other tools** like [sigrok](https://sigrok.org/) or the [virtual-usb-analyzer](http://vusb-analyzer.sourceforge.net/). Integration with sigrok would be nice to show the packet level of USB.
+There's **no integration with other tools** like [sigrok](https://sigrok.org/) or the [virtual-usb-analyzer](http://vusb-analyzer.sourceforge.net/) mainly due to feature overlapping with existing tools and/or lack of developer interests.
 
 At least partly due to the lack of availability of boards, there hasn't been any
 progress over the years, particularly not with the original project founder bushing

--- a/software/host/.gitignore
+++ b/software/host/.gitignore
@@ -7,3 +7,7 @@ libov.dylib
 libov.dll
 libov.exp
 libov.lib
+build/**
+dist/**
+__pycache__/**
+ovctl.spec

--- a/software/host/package.bat
+++ b/software/host/package.bat
@@ -1,4 +1,4 @@
 @echo off
 REM Install PyInstaller into the virtualenv and run this script.
 
-pyinstaller --add-binary 'libov.dll:.' --add-data 'ov3.fwpkg:.' ovctl.py
+pyinstaller --add-binary "libov.dll:." --add-data "ov3.fwpkg:." ovctl.py

--- a/software/host/package.bat
+++ b/software/host/package.bat
@@ -1,0 +1,4 @@
+@echo off
+REM Install PyInstaller into the virtualenv and run this script.
+
+pyinstaller --add-binary 'libov.dll:.' --add-data 'ov3.fwpkg:.' ovctl.py

--- a/software/host/package.ps1
+++ b/software/host/package.ps1
@@ -1,0 +1,3 @@
+# Install PyInstaller into the virtualenv and run this script.
+
+pyinstaller --add-binary 'libov.dll:.' --add-data 'ov3.fwpkg:.' ovctl.py

--- a/software/host/package.sh
+++ b/software/host/package.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Install PyInstaller into the virtualenv and run this script.
+
+pyinstaller --add-binary 'libov.so:.' --add-data 'ov3.fwpkg:.' --add-data '52-openvizsla.rules:udev' ovctl.py


### PR DESCRIPTION
Added 3 convenience scripts for invoking PyInstaller to package ovctl so no need to fire up virtualenv every time or messing with the system Python before using ovctl. It also makes transporting builds to another machine easier, especially on Windows.

Also added some notes about the recent Wireshark release that introduced the long awaited USBLL packet reassembler.