### PR TITLE
Fix invalid "CRC failed" message after successful FPGA configuration

### DIFF
--- a/software/host/fpgaconfig.c
+++ b/software/host/fpgaconfig.c
@@ -269,20 +269,21 @@ ConfigEnd(FTDIDevice *dev)
   if (err)
     return err;
 
-  if (byte & PORTB_INIT_BIT) {
-    fprintf(stderr, "FPGA: CRC OK\n");
-  } else {
-    fprintf(stderr, "FPGA: CRC failed\n");
-    // return -1     (not sure if this will work without a pull-up resistor)
-  }
-
+  /*
+   * DONE is high on success.  Check DONE first because INIT becomes
+   * User I/O and no longer reflects CRC status once DONE goes high.
+   */
   if (byte & PORTB_DONE_BIT) {
     fprintf(stderr, "FPGA: configured\n");
     return 0;
-  } else {
-    fprintf(stderr, "FPGA: Configuration error!\n");
-    return -1;
   }
+
+  if (byte & PORTB_INIT_BIT)
+    fprintf(stderr, "FPGA: configuration failed (DONE not asserted)\n");
+  else
+    fprintf(stderr, "FPGA: configuration failed (CRC error)\n");
+
+  return -1;
 }
 
 int FPGA_GetConfigStatus(FTDIDevice * dev)
@@ -328,10 +329,6 @@ int FPGA_GetConfigStatus(FTDIDevice * dev)
       return err;
     }
   } while (err == LIBUSB_ERROR_IO);
-
-  if (!(byte & PORTB_INIT_BIT)) {
-    return -1;
-  }
 
   if (byte & PORTB_DONE_BIT) {
     return 0;


### PR DESCRIPTION
fpgaconfig.c sampled INIT_B ~10 ms after configuration and reported "CRC failed" whenever it read Low. 

Per UG380, INIT_B is only driven Low on a CRC error during configuration (and then DONE never asserts); once DONE is High the open-drain pin is no longer driven, so its level reflects only board/bitstream pull settings. 

A design that doesn't claim the INIT_B pad gets bitgen's default UnusedPin = PULLDOWN, which holds it Low after a perfectly good configuration. Trust DONE; consult INIT_B only while DONE is Low.

Validated on OpenVizsla 3.2 hardware.
